### PR TITLE
greatly rework the component

### DIFF
--- a/linux_gpios.orogen
+++ b/linux_gpios.orogen
@@ -1,27 +1,29 @@
-name "linux_gpios"
+# frozen_string_literal: true
 
-import_types_from "std"
-import_types_from "raw_io"
-import_types_from "linux_gpiosTypes.hpp"
+name 'linux_gpios'
+
+import_types_from 'std'
+import_types_from 'raw_io'
+import_types_from 'linux_gpiosTypes.hpp'
 
 # Task that reads and/or writes GPIOs
-task_context "Task" do
+task_context 'Task' do
     # This is the default from now on, and should not be removed. Rock will
     # transition to a setup where all components use a configuration step.
     needs_configuration
 
     # The set of GPIOs that should be written, as a list of GPIO IDs
-    property "w_configuration", "/linux_gpios/Configuration"
+    property 'output_configuration', '/std/vector</linux_gpios/OutputConfiguration>'
 
     # The port on which the 'output' GPIOs can be commanded, in the same order
     # than the 'inputs' property
-    input_port 'w_commands', '/linux_gpios/GPIOState'
+    input_port 'output_pins', '/linux_gpios/GPIOState'
 
     # The set of GPIOs that should be read, as a list of GPIO IDs
-    property "r_configuration", "/linux_gpios/Configuration"
+    property 'input_configuration', '/std/vector</linux_gpios/InputConfiguration>'
 
     # The port on which the state of the GPIOs that are read is exported
-    output_port 'r_states', '/linux_gpios/GPIOState'
+    output_port 'input_pins', '/linux_gpios/GPIOState'
 
     periodic 0.01
 

--- a/linux_gpiosTypes.hpp
+++ b/linux_gpiosTypes.hpp
@@ -6,10 +6,29 @@
 #include <raw_io/Digital.hpp>
 
 namespace linux_gpios {
-    struct Configuration
-    {
-        std::vector<int32_t> ids;
+    struct InputConfiguration {
+        int id;
+        InputConfiguration()
+            : id(-1) {
+        }
     };
+
+    struct OutputConfiguration {
+        enum NoDataAction {
+            KEEP, USE_DEFAULT
+        };
+
+        int id;
+        NoDataAction on_no_data;
+        bool default_state;
+
+        OutputConfiguration()
+            : id(-1)
+            , on_no_data(KEEP)
+            , default_state(false) {
+        }
+    };
+
     struct GPIOState
     {
         base::Time time;

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -105,13 +105,36 @@ namespace linux_gpios{
         void cleanupHook();
 
     private:
-        std::vector<int> m_write_fds;
-        std::vector<int> m_read_fds;
+        struct ConfiguredOutput : public OutputConfiguration {
+            int fd;
+
+            explicit ConfiguredOutput(int fd, OutputConfiguration const& other)
+                : OutputConfiguration(other)
+                , fd(fd) {
+            }
+        };
+
+        struct ConfiguredInput : public InputConfiguration {
+            int fd;
+
+            explicit ConfiguredInput(int fd, InputConfiguration const& other)
+                : InputConfiguration(other)
+                , fd(fd) {
+            }
+        };
+
+        std::vector<ConfiguredOutput> mOutput;
+        std::vector<ConfiguredInput> mInput;
 
         GPIOState mState;
         GPIOState mCommand;
 
-        static std::vector<int> openGPIOs(Configuration const& config, int mode);
+        template<typename T, typename C>
+        static std::vector<T> openGPIOs(std::vector<C> const& config, int mode);
+        void handleOnNoData(bool throw_on_error = true);
+
+        void writeOutputs();
+        void readInputs();
         bool readGPIO(int fd);
         void writeGPIO(int fd, bool value);
         void closeAll();


### PR DESCRIPTION
- replace _r_ prefix by input/output. The 'input' and 'output' are
  referring to the 'pins' (i.e. the GPIO configuration)
- create a on_no_data flag that makes linux_gpios write a default
  value if there is no data on a given port. Apply the same rules
  on stop, and (best effort) on cleanup. This is to ensure that
  critical elements that could be commanded by the GPIOs are left
  in a known good state.