### PR TITLE
feat: edge-triggered output and default values

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "orogen",
+            "request": "launch",
+            "name": "(drivers/orogen/linux_gpios) run task_under_test",
+            "deploy": "linux_gpios::Task",
+            "deployAs": "task_under_test"
+        }
+
+    ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@ cmake_minimum_required(VERSION 2.6)
 SET (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.orogen/config")
 INCLUDE(linux_gpiosBase)
 
+# Do not forget to add syskit as a test dependency in manifest.xml
+#  <test_depend name="tools/syskit" />
+if (ROCK_TEST_ENABLED)
+    enable_testing()
+    find_package(Syskit REQUIRED)
+    syskit_orogen_tests(test)
+endif()
+
 # FIND_PACKAGE(KDL)
 # FIND_PACKAGE(OCL)
 

--- a/linux_gpios.orogen
+++ b/linux_gpios.orogen
@@ -15,6 +15,11 @@ task_context "Task" do
     # Root of GPIOs in sysfs. Exclusively for testing
     property "sysfs_gpio_path", "/std/string", "/sys/class/gpio/gpio"
 
+    # Whether the output should be written only when change
+    #
+    # It is false to keep backward compatibility. We recommend setting to true
+    property "edge_triggered_output", "/bool", false
+
     # The set of GPIOs that should be written, as a list of GPIO IDs
     property "w_configuration", "/linux_gpios/Configuration"
 

--- a/linux_gpios.orogen
+++ b/linux_gpios.orogen
@@ -2,6 +2,8 @@
 
 name "linux_gpios"
 
+using_library "base-logging", typekit: false
+
 import_types_from "std"
 import_types_from "raw_io"
 import_types_from "linux_gpiosTypes.hpp"
@@ -21,14 +23,14 @@ task_context "Task" do
     property "edge_triggered_output", "/bool", false
 
     # The set of GPIOs that should be written, as a list of GPIO IDs
-    property "w_configuration", "/linux_gpios/Configuration"
+    property "w_configuration", "/linux_gpios/WriteConfiguration"
 
     # The port on which the 'output' GPIOs can be commanded, in the same order
     # than the 'inputs' property
     input_port "w_commands", "/linux_gpios/GPIOState"
 
     # The set of GPIOs that should be read, as a list of GPIO IDs
-    property "r_configuration", "/linux_gpios/Configuration"
+    property "r_configuration", "/linux_gpios/ReadConfiguration"
 
     # The port on which the state of the GPIOs that are read is exported
     output_port "r_states", "/linux_gpios/GPIOState"

--- a/linux_gpios.orogen
+++ b/linux_gpios.orogen
@@ -12,6 +12,9 @@ task_context "Task" do
     # transition to a setup where all components use a configuration step.
     needs_configuration
 
+    # Root of GPIOs in sysfs. Exclusively for testing
+    property "sysfs_gpio_path", "/std/string", "/sys/class/gpio/gpio"
+
     # The set of GPIOs that should be written, as a list of GPIO IDs
     property "w_configuration", "/linux_gpios/Configuration"
 

--- a/linux_gpios.orogen
+++ b/linux_gpios.orogen
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 name "linux_gpios"
 
 import_types_from "std"
@@ -15,13 +17,13 @@ task_context "Task" do
 
     # The port on which the 'output' GPIOs can be commanded, in the same order
     # than the 'inputs' property
-    input_port 'w_commands', '/linux_gpios/GPIOState'
+    input_port "w_commands", "/linux_gpios/GPIOState"
 
     # The set of GPIOs that should be read, as a list of GPIO IDs
     property "r_configuration", "/linux_gpios/Configuration"
 
     # The port on which the state of the GPIOs that are read is exported
-    output_port 'r_states', '/linux_gpios/GPIOState'
+    output_port "r_states", "/linux_gpios/GPIOState"
 
     periodic 0.01
 

--- a/linux_gpios.orogen
+++ b/linux_gpios.orogen
@@ -30,5 +30,5 @@ task_context "Task" do
 
     periodic 0.01
 
-    exception_states :IO_ERROR
+    exception_states :IO_ERROR, :UNEXPECTED_COMMAND_SIZE
 end

--- a/linux_gpiosTypes.hpp
+++ b/linux_gpiosTypes.hpp
@@ -1,17 +1,30 @@
 #ifndef linux_gpios_TYPES_HPP
 #define linux_gpios_TYPES_HPP
 
-#include <vector>
 #include <base/Time.hpp>
 #include <raw_io/Digital.hpp>
+#include <vector>
 
 namespace linux_gpios {
-    struct Configuration
-    {
+    struct ReadConfiguration {
         std::vector<int32_t> ids;
     };
-    struct GPIOState
-    {
+
+    struct WriteConfiguration {
+        std::vector<int32_t> ids;
+
+        /** How long without input before the component writes default values */
+        base::Time timeout;
+
+        /** If non-empty, values to write to the GPIOs if it has no explicit command
+         *
+         * Default values are written if there was no command for `timeout`, or if
+         * there is nothing connected to the command port
+         */
+        std::vector<uint8_t> defaults;
+    };
+
+    struct GPIOState {
         base::Time time;
         std::vector<raw_io::Digital> states;
     };

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,6 +1,6 @@
 <package>
   <description brief="Interface to the Linux GPIOs">
-  
+
   </description>
   <author>Sylvain Joyeux/sylvain.joyeux@13robotics.com</author>
   <license></license>
@@ -9,4 +9,5 @@
   <depend package="base/cmake" />
   <depend package="base/orogen/types" />
   <depend package="drivers/orogen/raw_io" />
+  <test_depend package="tools/syskit" />
 </package>

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -33,9 +33,9 @@ bool Task::configureHook()
     if (!TaskBase::configureHook())
         return false;
 
-    m_write_fds = openGPIOs(_w_configuration.get(), O_WRONLY);
+    m_write_fds = openGPIOs(_w_configuration.get(), O_WRONLY, _sysfs_gpio_path.get());
     mCommand.states.resize(m_write_fds.size());
-    m_read_fds = openGPIOs(_r_configuration.get(), O_RDONLY);
+    m_read_fds = openGPIOs(_r_configuration.get(), O_RDONLY, _sysfs_gpio_path.get());
     mState.states.resize(m_read_fds.size());
     return true;
 }
@@ -116,11 +116,13 @@ namespace {
     };
 }
 
-std::vector<int> Task::openGPIOs(Configuration const& config, int mode)
+std::vector<int> Task::openGPIOs(Configuration const& config,
+    int mode,
+    string const& sysfs_root_path)
 {
     CloseGuard guard;
     for (int id : config.ids) {
-        string sysfs_path = "/sys/class/gpio/gpio" + to_string(id) + "/value";
+        string sysfs_path = sysfs_root_path + "/gpio" + to_string(id) + "/value";
         int fd = open(sysfs_path.c_str(), mode);
         if (fd == -1) {
             throw runtime_error("Failed to open " + sysfs_path + ": " + strerror(errno));

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -58,10 +58,9 @@ void Task::updateHook()
     handleWriteSide();
 
     auto now = base::Time::now();
-    bool hasUpdate = false;
+    bool hasUpdate = !_edge_triggered_output.get();
     for (size_t i = 0; i < m_read_fds.size(); ++i) {
         int fd = m_read_fds[i];
-        hasUpdate = true;
         bool value = readGPIO(fd);
         if (m_state.states[i].data != value) {
             hasUpdate = true;

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -78,6 +78,11 @@ void Task::updateHook()
 void Task::handleWriteSide()
 {
     while (_w_commands.read(m_command, false) == RTT::NewData) {
+        if (m_command.states.size() != m_write_fds.size()) {
+            exception(UNEXPECTED_COMMAND_SIZE);
+            return;
+        }
+
         for (size_t i = 0; i < m_write_fds.size(); ++i) {
             writeGPIO(m_write_fds[i], m_command.states[i].data);
         }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -112,14 +112,15 @@ namespace linux_gpios {
         std::vector<int> m_write_fds;
         std::vector<int> m_read_fds;
 
-        GPIOState mState;
-        GPIOState mCommand;
+        GPIOState m_state;
+        GPIOState m_command;
 
         static std::vector<int> openGPIOs(Configuration const& config,
             int mode,
             std::string const& sysfs_root_path);
         bool readGPIO(int fd);
         void writeGPIO(int fd, bool value);
+        void handleWriteSide();
         void closeAll();
     };
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -115,7 +115,9 @@ namespace linux_gpios {
         GPIOState mState;
         GPIOState mCommand;
 
-        static std::vector<int> openGPIOs(Configuration const& config, int mode);
+        static std::vector<int> openGPIOs(Configuration const& config,
+            int mode,
+            std::string const& sysfs_root_path);
         bool readGPIO(int fd);
         void writeGPIO(int fd, bool value);
         void closeAll();

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -5,12 +5,15 @@
 
 #include "linux_gpios/TaskBase.hpp"
 
-namespace linux_gpios{
+namespace linux_gpios {
 
     /*! \class Task
-     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
-     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
-     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
      * Task that reads and/or writes GPIOs
      * \details
      * The name of a TaskContext is primarily defined via:
@@ -19,32 +22,33 @@ namespace linux_gpios{
          task('custom_task_name','linux_gpios::Task')
      end
      \endverbatim
-     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
      */
-    class Task : public TaskBase
-    {
-	friend class TaskBase;
+    class Task : public TaskBase {
+        friend class TaskBase;
+
     protected:
-
-
-
     public:
         /** TaskContext constructor for Task
-         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
-         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
          */
         Task(std::string const& name = "linux_gpios::Task");
 
         /** TaskContext constructor for Task
-         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
-         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable for nameservices. \param engine The RTT Execution engine to be
+         * used for this task, which serialises the execution of all commands, programs,
+         * state machines and incoming events for a task.
          *
          */
         Task(std::string const& name, RTT::ExecutionEngine* engine);
 
         /** Default deconstructor of Task
          */
-	~Task();
+        ~Task();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -109,17 +109,19 @@ namespace linux_gpios {
         void cleanupHook();
 
     private:
+        WriteConfiguration m_write_configuration;
         std::vector<int> m_write_fds;
         std::vector<int> m_read_fds;
 
         GPIOState m_state;
         GPIOState m_command;
 
-        static std::vector<int> openGPIOs(Configuration const& config,
+        static std::vector<int> openGPIOs(std::vector<int32_t> const& ids,
             int mode,
             std::string const& sysfs_root_path);
         bool readGPIO(int fd);
         void writeGPIO(int fd, bool value);
+        void writeDefaults();
         void handleWriteSide();
         void closeAll();
     };

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+using_task_library "linux_gpios"
+
+describe OroGen.linux_gpios.Task do
+    run_live
+
+    attr_reader :task
+
+    before do
+        @gpio_root = Pathname(Dir.mktmpdir)
+
+        @task = syskit_deploy(
+            OroGen.linux_gpios.Task
+                  .deployed_as("task_under_test")
+        )
+        @task.properties.sysfs_gpio_path = @gpio_root.to_s
+    end
+
+    after do
+        @gpio_root&.rmtree
+    end
+
+    it "fails to configure if a GPIO does not exist" do
+        task.properties.r_configuration = { ids: [124] }
+        assert_raises(Roby::EmissionFailed) do
+            syskit_configure(task)
+        end
+    end
+
+    it "fails to configure if a GPIO does not exist" do
+        task.properties.r_configuration = { ids: [124] }
+        assert_raises(Roby::EmissionFailed) do
+            syskit_configure(task)
+        end
+    end
+
+    it "outputs the initial state of the GPIO on start" do
+        make_fake_gpio(124, false)
+        task.properties.r_configuration = { ids: [124] }
+        syskit_configure(task)
+
+        sample = expect_execution { task.start! }.to do
+            have_one_new_sample task.r_states_port
+        end
+
+        assert_equal [0], sample.states.map(&:data)
+    end
+
+    it "writes and reads new state on the GPIO" do
+        make_fake_gpio(124, "0")
+        task.properties.w_configuration = { ids: [124] }
+        task.properties.r_configuration = { ids: [124] }
+        syskit_configure_and_start(task)
+
+        command = { states: [{ data: 1 }] }
+        expect_execution { syskit_write(task.w_commands_port, command) }.to do
+            have_one_new_sample(task.r_states_port)
+                .matching { |s| s.states[0].data == 1 }
+        end
+
+        assert_equal "1", read_fake_gpio(124)
+    end
+
+    def make_fake_gpio(id, value)
+        (@gpio_root / "gpio#{id}").mkpath
+        write_fake_gpio(id, value)
+    end
+
+    def write_fake_gpio(id, value)
+        (@gpio_root / "gpio#{id}" / "value").write(value ? "1" : "0")
+    end
+
+    def read_fake_gpio(id)
+        (@gpio_root / "gpio#{id}" / "value").read
+    end
+end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -64,6 +64,28 @@ describe OroGen.linux_gpios.Task do
         assert_equal "1", read_fake_gpio(124)
     end
 
+    it "rejects a command input whose size is lower than the expected" do
+        make_fake_gpio(124, "0")
+        task.properties.w_configuration = { ids: [124] }
+        syskit_configure_and_start(task)
+
+        command = { states: [] }
+        expect_execution { syskit_write(task.w_commands_port, command) }.to do
+            emit task.unexpected_command_size_event
+        end
+    end
+
+    it "rejects a command input whose size is greater than the expected" do
+        make_fake_gpio(124, "0")
+        task.properties.w_configuration = { ids: [124] }
+        syskit_configure_and_start(task)
+
+        command = { states: [{ data: 1 }, { data: 1 }] }
+        expect_execution { syskit_write(task.w_commands_port, command) }.to do
+            emit task.unexpected_command_size_event
+        end
+    end
+
     def make_fake_gpio(id, value)
         (@gpio_root / "gpio#{id}").mkpath
         write_fake_gpio(id, value)

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -49,8 +49,8 @@ describe OroGen.linux_gpios.Task do
         assert_equal [0], sample.states.map(&:data)
     end
 
-    it "writes and reads new state on the GPIO" do
-        make_fake_gpio(124, "0")
+    it "writes a new state and reads it back" do
+        make_fake_gpio(124, false)
         task.properties.w_configuration = { ids: [124] }
         task.properties.r_configuration = { ids: [124] }
         syskit_configure_and_start(task)
@@ -58,14 +58,35 @@ describe OroGen.linux_gpios.Task do
         command = { states: [{ data: 1 }] }
         expect_execution { syskit_write(task.w_commands_port, command) }.to do
             have_one_new_sample(task.r_states_port)
-                .matching { |s| s.states[0].data == 1 }
+                .matching { |s| s.states[0].data != 0 }
         end
 
-        assert_equal "1", read_fake_gpio(124)
+        assert read_fake_gpio(124)
+    end
+
+    it "outputs the current state periodically by default" do
+        make_fake_gpio(124, false)
+        task.properties.r_configuration = { ids: [124] }
+        syskit_configure_and_start(task)
+
+        10.times do
+            expect_execution.to { have_one_new_sample(task.r_states_port) }
+        end
+    end
+
+    it "writes only on state change if edge_triggered_output is set" do
+        make_fake_gpio(124, false)
+        task.properties.edge_triggered_output = true
+        task.properties.r_configuration = { ids: [124] }
+        syskit_configure_and_start(task)
+
+        expect_execution.to do
+            have_no_new_sample(task.r_states_port, at_least_during: 1)
+        end
     end
 
     it "rejects a command input whose size is lower than the expected" do
-        make_fake_gpio(124, "0")
+        make_fake_gpio(124, false)
         task.properties.w_configuration = { ids: [124] }
         syskit_configure_and_start(task)
 
@@ -76,7 +97,7 @@ describe OroGen.linux_gpios.Task do
     end
 
     it "rejects a command input whose size is greater than the expected" do
-        make_fake_gpio(124, "0")
+        make_fake_gpio(124, false)
         task.properties.w_configuration = { ids: [124] }
         syskit_configure_and_start(task)
 
@@ -96,6 +117,6 @@ describe OroGen.linux_gpios.Task do
     end
 
     def read_fake_gpio(id)
-        (@gpio_root / "gpio#{id}" / "value").read
+        (@gpio_root / "gpio#{id}" / "value").read == "1"
     end
 end


### PR DESCRIPTION
This pull request resolves one major operational issue, and one rather critical one (when using GPIOs to command safety-related equipment):

**default values**: the component will now output a configured default value on timeout or when there is nothing commanding the GPIO. This ensures that we can maintain a "safe state" by simply keeping the GPIO component running.

**edge-triggered output**: the component can now be configured to output only on value change, instead of doing it all the time. This will massively reduce the size of logs from GPIO components.