### PR TITLE
fix: heisenbug on stop / exception for TimerGPIOTask

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -8,6 +8,7 @@
   <logo>http://</logo>
   <depend package="base/cmake" />
   <depend package="base/orogen/types" />
+  <depend package="base/logging" />
   <depend package="drivers/orogen/raw_io" />
   <test_depend package="tools/syskit" />
 </package>

--- a/tasks/TimerGPIOTask.cpp
+++ b/tasks/TimerGPIOTask.cpp
@@ -95,9 +95,15 @@ void TimerGPIOTask::stopHook()
     }
     catch(timeout_error const& e) {
         LOG_ERROR_S << e.what();
+        if (state() != EXCEPTION) {
+            exception();
+        }
     }
     catch(input_error const& e) {
         LOG_ERROR_S << e.what();
+        if (state() != EXCEPTION) {
+            exception();
+        }
     }
 }
 void TimerGPIOTask::cleanupHook()

--- a/tasks/TimerGPIOTask.cpp
+++ b/tasks/TimerGPIOTask.cpp
@@ -2,11 +2,20 @@
 
 #include "TimerGPIOTask.hpp"
 #include "raw_io/Digital.hpp"
+#include <base-logging/Logging.hpp>
 #include <chrono>
 #include <thread>
 
 using namespace linux_gpios;
 using namespace std;
+
+struct input_error : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+struct timeout_error : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
 
 TimerGPIOTask::TimerGPIOTask(std::string const& name)
     : TimerGPIOTaskBase(name)
@@ -75,17 +84,21 @@ void TimerGPIOTask::errorHook()
 
 void TimerGPIOTask::exceptionHook()
 {
-    try {
-        writeMessageAndCheckFeedback(m_switch_timeout, !_set_state.get());
-    }
-    catch (const std::exception& e) {
-    }
 }
 
 void TimerGPIOTask::stopHook()
 {
     TimerGPIOTaskBase::stopHook();
-    writeMessageAndCheckFeedback(m_timeout, !_set_state.get());
+
+    try {
+        writeMessageAndCheckFeedback(m_timeout, !_set_state.get());
+    }
+    catch(timeout_error const& e) {
+        LOG_ERROR_S << e.what();
+    }
+    catch(input_error const& e) {
+        LOG_ERROR_S << e.what();
+    }
 }
 void TimerGPIOTask::cleanupHook()
 {
@@ -112,7 +125,7 @@ void TimerGPIOTask::writeMessageAndCheckFeedback(base::Time timeout, bool value)
         if (_feedback.read(feedback) == RTT::NewData) {
             received = true;
             if (feedback.states.size() > 1) {
-                throw std::runtime_error("Feedback size is bigger than 1.");
+                throw input_error("Feedback size is bigger than 1.");
             }
             if (feedback.states[0].data == value) {
                 return;
@@ -122,12 +135,12 @@ void TimerGPIOTask::writeMessageAndCheckFeedback(base::Time timeout, bool value)
     }
 
     if (received) {
-        throw std::runtime_error(
+        throw timeout_error(
             "Feedback timeout: received GPIO feedback, but none with value " +
             to_string(value) + " within " + to_string(timeout.toSeconds()) + " seconds");
     }
     else {
-        throw std::runtime_error(
+        throw timeout_error(
             "Feedback timeout: did not receive any GPIO feedback within " +
             to_string(timeout.toSeconds()) + " seconds");
     }

--- a/test/timer_gpio_task_test.rb
+++ b/test/timer_gpio_task_test.rb
@@ -42,7 +42,7 @@ describe OroGen.linux_gpios.TimerGPIOTask do
                    "but got #{toc - tic}"
         end
 
-        it "it sets default value to gpio in case of stop hook" do
+        it "resets the GPIO to its initial value when stopped" do
             @task = create_configure_and_start_task(duration: 2)
             feedback_writer = syskit_create_writer(task.feedback_port)
 
@@ -53,14 +53,10 @@ describe OroGen.linux_gpios.TimerGPIOTask do
                         .matching { |v| v.states[0].data == 0 }
                     not_emit task.stop_event, within: 0.5
                 end
-        
+
             expect_execution
                 .poll { feedback_writer.write(off_state) }
-                .to do
-                    have_one_new_sample(task.gpio_state_port)
-                        .matching { |v| v.states[0].data == 0 }
-                    emit task.stop_event
-                end
+                .to_emit task.stop_event
         end
     end
 


### PR DESCRIPTION
The issue that this is catching is that when TimerGPIOTask is failure handling during stop / exception

- first mistake is that both exceptionHook and stopHook are trying to cleanup. exception() calls stopHook, so no need
- the second mistake is to throw in stopHook. When this happens, RTT assumes that cleanup did not happen as it should, and the component goes into FATAL

The heisenbug was that the component goes into FATAL and syskit then kills the process as its recovery path for FATAL. Every once and a while, this causes the writer to fail to write and we get an exception.

This PR fixes both by catching the exceptions and showing an error message instead, transitioning cleanly to exception. The last problematic / tricky bit is to NOT call exception() in stopHook without checking for the current state, as exception() currently calls stop() unconditionally (i.e. this is an infinite recursion). Note that in this case, we'll timeout twice in the exception case, but that's better than the alternative which would pretend that everything's alright.

This last behaviour (exception() calling stop() right away) is on the list of things to be fixed.